### PR TITLE
adds basic support for min and max dates

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -289,7 +289,25 @@ angular.module("datetime").directive("datetime", function(datetime, $log){
 
 			ngModel.$setValidity("datetime", true);
 			// Create new date to make Angular notice the difference.
-			return new Date(parser.getDate().getTime());
+			var date_obj = new Date(parser.getDate().getTime());
+
+			if (attrs.min !== undefined) {
+        if (new Date(attrs.min) > date_obj) {
+          ngModel.$setValidity("min", false);
+          return undefined;
+        } else {
+          ngModel.$setValidity("min", true);
+        }
+      }
+			if (attrs.max !== undefined) {
+        if (new Date(attrs.max) < date_obj) {
+          ngModel.$setValidity("max", false);
+          return undefined;
+        } else {
+          ngModel.$setValidity("max", true);
+        }
+      }
+      return date_obj;
 		});
 
 		ngModel.$formatters.push(function(modelValue){


### PR DESCRIPTION
Sorry for difference in spacing and lack of any tests. It is just a handful of lines, so hopefully it won't be too difficult to look at. I stumbled across your module after being dissatisfied with input[date]'s fallback for browsers that do not support the HTML5 input. I did however require min and max validations. I haven't created too many directives, so my addition may not be optimal. Anywho, I hope you find this useful.