### PR TITLE
Timezone fix

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -182,7 +182,7 @@ angular.module("datetime").factory("datetime", function($locale){
 		"Z": {
 			name: "timezone",
 			type: "regex",
-			regex: /[+-]\d{4}/
+			regex: /[+-]\d{2}:?\d{2}/
 		},
 		"string": {
 			name: "string",
@@ -337,7 +337,7 @@ angular.module("datetime").factory("datetime", function($locale){
 				node.value = getWeek(date);
 				break;
 			case "timezone":
-				node.value = (date.getTimezoneOffset() > 0 ? "-" : "+") + num2str(Math.abs(date.getTimezoneOffset() / 60), 2, 2) + "00";
+				node.value = (date.getTimezoneOffset() > 0 ? "-" : "+") + num2str(Math.abs(date.getTimezoneOffset() / 60), 2, 2) + ":00";
 				break;
 		}
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -557,7 +557,7 @@ angular.module("datetime").factory("datetime", function($locale){
 				break;
 
 			case "regex":
-				m = p.regex.exec(text.substr(pos));
+				m = node.token.regex.exec(text.substr(pos));
 				if (!m || m.index != 0) {
 					throw {
 						code: "REGEX_MISMATCH",


### PR DESCRIPTION
Tried to use this directive with `datetime-model="yyyy-MM-ddTHH:mm:ss.sssZ"` but it failed with undefined reference error. Also format of timezone offset is expected without `:`. According to https://www.ietf.org/rfc/rfc3339.txt there should be `:` sign. I found that only angular date filter uses format without `:`.