### PR TITLE
New timezone token ZZ for +02:00 timezone format

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,6 +30,11 @@ module.exports = function(grunt) {
 		},
 		eslint: {
 			target: ["src/*.js"]
+		},
+		karma: {
+			unit: {
+				configFile: 'karma.conf.js'
+			}
 		}
 	});
 
@@ -39,8 +44,10 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks("grunt-contrib-watch");
 	grunt.loadNpmTasks("grunt-ng-annotate");
 	grunt.loadNpmTasks("grunt-eslint");
+	grunt.loadNpmTasks('grunt-karma');
 
 	// Default task(s).
 	grunt.registerTask("default", ["eslint", "ngAnnotate"]);
+	grunt.registerTask('test', ['ngAnnotate', 'karma']);
 
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,7 +12,6 @@ module.exports = function(config) {
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['jasmine'],
 
-
     // list of files / patterns to load in the browser
     files: [
 	  'bower_components/angular/angular.js',
@@ -58,7 +57,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Firefox'],
+    browsers: ['PhantomJS'],
 
 
     // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "karma": "^0.13.0",
     "karma-chrome-launcher": "^0.1.8",
     "karma-firefox-launcher": "^0.1.4",
-    "karma-jasmine": "^0.3.5"
+    "karma-jasmine": "^0.3.5",
+    "karma-phantomjs-launcher": "^1.0.0",
+    "phantomjs-prebuilt": "^2.1.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-eslint": "^18.0.0",
+    "grunt-karma": "^0.12.2",
     "grunt-ng-annotate": "^0.10.0",
     "jasmine-core": "^2.2.0",
-    "karma": "^0.12.31",
+    "karma": "^0.13.0",
     "karma-chrome-launcher": "^0.1.8",
     "karma-firefox-launcher": "^0.1.4",
     "karma-jasmine": "^0.3.5"

--- a/src/factory.js
+++ b/src/factory.js
@@ -2,7 +2,7 @@ angular.module("datetime").factory("datetime", function($locale){
 	// Fetch date and time formats from $locale service
 	var formats = $locale.DATETIME_FORMATS;
 	// Valid format tokens. 1=sss, 2=''
-	var tokenRE = /yyyy|yy|y|M{1,4}|dd?|EEEE?|HH?|hh?|mm?|ss?|([.,])sss|a|Z|ww|w|'(([^']+|'')*)'/g;
+	var tokenRE = /yyyy|yy|y|M{1,4}|dd?|EEEE?|HH?|hh?|mm?|ss?|([.,])sss|a|Z{1,2}|ww|w|'(([^']+|'')*)'/g;
 	// Token definition
 	var definedTokens = {
 		"y": {
@@ -184,6 +184,11 @@ angular.module("datetime").factory("datetime", function($locale){
 			type: "regex",
 			regex: /[+-]\d{4}/
 		},
+		"ZZ": {
+			name: "timezoneWithColon",
+			type: "regex",
+			regex: /[+-]\d{2}:\d{2}/
+		},
 		"string": {
 			name: "string",
 			type: "static"
@@ -338,6 +343,9 @@ angular.module("datetime").factory("datetime", function($locale){
 				break;
 			case "timezone":
 				node.value = (date.getTimezoneOffset() > 0 ? "-" : "+") + num2str(Math.abs(date.getTimezoneOffset() / 60), 2, 2) + "00";
+				break;
+			case "timezoneWithColon":
+				node.value = (date.getTimezoneOffset() > 0 ? "-" : "+") + num2str(Math.abs(date.getTimezoneOffset() / 60), 2, 2) + ":00";
 				break;
 		}
 

--- a/test/test.js
+++ b/test/test.js
@@ -153,7 +153,7 @@ describe("datetime directive", function(){
 			$rootScope.date = new Date;
 			
 			var element = $compile("<input type='text' datetime='{{format}}' ng-model='date'>")($rootScope);
-			
+
 			$rootScope.$digest();
 			
 			expect(element.val()).toEqual($date($rootScope.date, format));
@@ -169,4 +169,23 @@ describe("datetime directive", function(){
 		
 		expect(element.val()).toEqual("+0000");
 	});
+
+	it("should allow : when using Z:Z token", function(){
+		$rootScope.date = new Date;
+
+		var element = $compile("<input type='text' datetime='ZZ' ng-model='date'>")($rootScope);
+
+		$rootScope.$digest();
+
+		var timezoneOffset = -new Date().getTimezoneOffset() / 60;
+		var isNegative = timezoneOffset < 0;
+
+		// add leading zeros
+		if (timezoneOffset < 10) {
+			timezoneOffset = (isNegative ? "-0" : "+0") + Math.abs(timezoneOffset);
+		}
+
+		expect(element.val()).toEqual(timezoneOffset + ":00");
+	});
+
 });


### PR DESCRIPTION
This PR adds support for ZZ format token to output date with `+02:00` format timezone.

There also added `grunt test` task for running tests in PhantomJS.

I haven't updated `README.md`.