### PR TITLE
Jump on next segment when pressing separator key

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Check demo page for live example.
 <input type="text" datetime="yyyy-MM-dd" ng-model="myDate" min="Jan 1, 1990" max="Dec 31, 2050">
 <input type="text" datetime="yyyy-MM-dd" ng-model="myDate" datetime-model="yyyy-MM-ddTHH:mm:ss">
 <input type="text" datetime="yyyy-MM-dd" ng-model="myDate" default="Jan 1, 2000">
+<input type="text" datetime="dd.MM.yyyy" ng-model="myDate" datetime-separator=",">
 ```
 
 Parsing errors
@@ -105,6 +106,7 @@ Changelog
 ---------
 * next
     - jump on the next segment on pressing next separator key
+    - customizable separator key
 * 3.0.1 (Apr 9, 2016)
 	- Fix validator and datetime-model bug. [#27](https://github.com/eight04/angular-datetime/issues/27)
 * 3.0.0 (Apr 1, 2016)

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Todos
 
 Changelog
 ---------
+* next
+    - jump on the next segment on pressing next separator key
 * 3.0.1 (Apr 9, 2016)
 	- Fix validator and datetime-model bug. [#27](https://github.com/eight04/angular-datetime/issues/27)
 * 3.0.0 (Apr 1, 2016)

--- a/example/demo-angular-1.5.html
+++ b/example/demo-angular-1.5.html
@@ -134,5 +134,12 @@
 			<pre class="code"><code>{{data.myDateString2 | json}}</code></pre>
 		</label>
 	</div>
+	<h3>Custom separator</h3>
+	<p>Used to jump on the next segment when pressing separator key. In this example angular-datetime will jump on the next segment when pressing `.` or `,`.</p>
+	<div class="form-group">
+		<label>
+			<input type="text" class="form-control" datetime="dd.MM.yyyy" ng-model="data.myDate" datetime-separator=",">
+		</label>
+	</div>
 </body>
 </html>

--- a/example/demo.html
+++ b/example/demo.html
@@ -135,5 +135,12 @@
 			<pre class="code"><code>{{data.myDateString2 | json}}</code></pre>
 		</label>
 	</div>
+	<h3>Custom separator</h3>
+	<p>Used to jump on the next segment when pressing separator key. In this example angular-datetime will jump on the next segment when pressing `.` or `,`.</p>
+	<div class="form-group">
+		<label>
+			<input type="text" class="form-control" datetime="dd.MM.yyyy" ng-model="data.myDate" datetime-separator=",">
+		</label>
+	</div>
 </body>
 </html>

--- a/example/demo.html
+++ b/example/demo.html
@@ -136,7 +136,7 @@
 		</label>
 	</div>
 	<h3>Custom separator</h3>
-	<p>Used to jump on the next segment when pressing separator key. In this example angular-datetime will jump on the next segment when pressing `.` or `,`.</p>
+	<p>Used to jump on the next segment when pressing separator key. In this example angular-datetime will jump on the next segment when pressing <code>.</code> or <code>,</code>.</p>
 	<div class="form-group">
 		<label>
 			<input type="text" class="form-control" datetime="dd.MM.yyyy" ng-model="data.myDate" datetime-separator=",">

--- a/src/directive.js
+++ b/src/directive.js
@@ -463,7 +463,7 @@ angular.module("datetime").directive("datetime", function(datetime, $log, $docum
 						nextSeparatorKeyCode = range.node.next.viewValue.charCodeAt(0);
 					}
 
-					if (e.keyCode === nextSeparatorKeyCode || e.keyCode == datetimeSeparator.charCodeAt(0)) {
+					if (e.keyCode === nextSeparatorKeyCode || (datetimeSeparator && e.keyCode == datetimeSeparator.charCodeAt(0))) {
 						e.preventDefault();
 						if (!ngModel.$error.datetime) {
 							selectRange(range, "next");

--- a/src/directive.js
+++ b/src/directive.js
@@ -193,7 +193,12 @@ angular.module("datetime").directive("datetime", function(datetime, $log, $docum
 				start: 0,
 				end: 0
 			};
-			
+		var datetimeSeparator;
+
+		if (angular.isDefined(attrs.datetimeSeparator)) {
+			datetimeSeparator = attrs.datetimeSeparator;
+		}
+
 		if (angular.isDefined(attrs.datetimeUtc)) {
 			parser.setTimezone("+0000");
 			if (modelParser) {
@@ -466,7 +471,7 @@ angular.module("datetime").directive("datetime", function(datetime, $log, $docum
 						nextSeparatorKeyCode = range.node.next.viewValue.charCodeAt(0);
 					}
 
-					if (e.keyCode === nextSeparatorKeyCode) {
+					if (e.keyCode === nextSeparatorKeyCode || e.keyCode == datetimeSeparator.charCodeAt(0)) {
 						e.preventDefault();
 						if (!ngModel.$error.datetime) {
 							selectRange(range, "next");

--- a/src/directive.js
+++ b/src/directive.js
@@ -459,7 +459,7 @@ angular.module("datetime").directive("datetime", function(datetime, $log, $docum
 				case "keypress":
 					var nextSeparatorKeyCode;
 					// check for separator only when there is a next node which is static string
-					if (range.node.next && range.node.next.token.name === 'string' && range.node.next.token.type === 'static') {
+					if (range.node.next && range.node.next.token.name === "string" && range.node.next.token.type === "static") {
 						nextSeparatorKeyCode = range.node.next.viewValue.charCodeAt(0);
 					}
 

--- a/src/directive.js
+++ b/src/directive.js
@@ -446,7 +446,21 @@ angular.module("datetime").directive("datetime", function(datetime, $log, $docum
 					break;
 
 				case "keypress":
-					if (isPrintableKey(e)) {
+					var nextSeparatorKeyCode;
+					// check for separator only when there is a next node which is static string
+					if (range.node.next && range.node.next.token.name === 'string' && range.node.next.token.type === 'static') {
+						nextSeparatorKeyCode = range.node.next.viewValue.charCodeAt(0);
+					}
+
+					if (e.keyCode === nextSeparatorKeyCode) {
+						e.preventDefault();
+						if (!ngModel.$error.datetime) {
+							selectRange(range, "next");
+						} else {
+							selectRange(errorRange);
+						}
+					}
+					else if (isPrintableKey(e)) {
 						setTimeout(function(){
 							range = getRange(element, parser.nodes, range.node);
 							if (isRangeAtEnd(range)) {

--- a/src/directive.js
+++ b/src/directive.js
@@ -192,7 +192,8 @@ angular.module("datetime").directive("datetime", function(datetime, $log, $docum
 				node: null,
 				start: 0,
 				end: 0
-			};
+			},
+			lastError;
 		var datetimeSeparator;
 
 		if (angular.isDefined(attrs.datetimeSeparator)) {
@@ -272,26 +273,15 @@ angular.module("datetime").directive("datetime", function(datetime, $log, $docum
 			try {
 				parser.parse(viewValue);
 			} catch (err) {
-				if (err.node) {
-					delete err.node.suggestedValue;
-				}
+				lastError = err;
 				$log.error(err);
 
 				ngModel.$setValidity("datetime", false);
 
-				if (err.code == "NUMBER_TOOSMALL" && err.match.length < err.node.token.maxLength) {
+				if (err.code == "NUMBER_TOOSHORT" || err.code == "NUMBER_TOOSMALL" && err.match.length < err.node.token.maxLength) {
 					errorRange.node = err.node;
 					errorRange.start = 0;
 					errorRange.end = err.match.length;
-				} else if (err.code == "NUMBER_TOOSHORT" && err.match.length < err.node.token.maxLength) {
-					// how many zeros we need to fulfil minLengthRequirement
-					var neededZeros = err.node.token.minLength - err.match.length;
-					// add leading zeros
-					var fixedValue = [viewValue.slice(0, err.pos), Array(neededZeros + 1).join("0"), viewValue.slice(err.pos)].join('')
-					// suggest correct value for node
-					err.node.suggestedValue = fixedValue;
-					// invalidate tooShort validator
-					ngModel.$setValidity("tooShort", false);
 				} else {
 					if (err.code == "LEADING_ZERO") {
 						viewValue = viewValue.substr(0, err.pos) + err.properValue + viewValue.substr(err.pos + err.match.length);
@@ -330,6 +320,8 @@ angular.module("datetime").directive("datetime", function(datetime, $log, $docum
 
 				return undefined;
 			}
+
+			lastError = null;
 
 			ngModel.$setValidity("datetime", true);
 
@@ -476,19 +468,13 @@ angular.module("datetime").directive("datetime", function(datetime, $log, $docum
 						if (!ngModel.$error.datetime) {
 							selectRange(range, "next");
 						}
-						else if (ngModel.$error.tooShort) { // for adding leading zeros for short string
-							if (range.node.suggestedValue) {
-								// apply suggested value and jump on next
-								parser.parse(range.node.suggestedValue); // try to apply suggested date
-								ngModel.$setViewValue(range.node.suggestedValue);
-								ngModel.$setValidity("tooShort", true);
-								ngModel.$render();
-								scope.$apply();
-								delete range.node.suggestedValue;
-								selectRange(range, "next");
-							} else {
-								selectRange(errorRange);
-							}
+						else if (lastError && lastError.code == "NUMBER_TOOSHORT") {
+							parser.nodeParseValue(lastError.node, lastError.properValue);
+							ngModel.$setViewValue(parser.getText());
+							ngModel.$setValidity("tooShort", true);
+							ngModel.$render();
+							scope.$apply();
+							selectRange(range, "next");
 						} else {
 							selectRange(errorRange);
 						}

--- a/src/directive.js
+++ b/src/directive.js
@@ -263,11 +263,13 @@ angular.module("datetime").directive("datetime", function(datetime, $log, $docum
 			}
 
 			ngModel.$setValidity("tooShort", true);
-			delete err.node.suggestedValue;
 
 			try {
 				parser.parse(viewValue);
 			} catch (err) {
+				if (err.node) {
+					delete err.node.suggestedValue;
+				}
 				$log.error(err);
 
 				ngModel.$setValidity("datetime", false);

--- a/src/factory.js
+++ b/src/factory.js
@@ -509,7 +509,8 @@ angular.module("datetime").factory("datetime", function($locale){
 						text: text,
 						node: p,
 						pos: pos,
-						match: value
+						match: value,
+						properValue: num2str(+value, p.token.minLength, p.token.maxLength)
 					};
 				}
 


### PR DESCRIPTION
Related issue: https://github.com/eight04/angular-datetime/issues/25

This PR adds option to jump on the next segment when pressing separator key. For example when filling month in format: `5.7.2016` you can press keys: `5` `.` `7` `.` and `2016`

Still in progress. To-Do:
- write tests
- fill leading zeros when format is `HH:mm:ss` - when pressing `4` and `:` on minute segment it should fill `04` and jump on seconds