### PR TITLE
Evaluate empty min/max attribute as always valid

### DIFF
--- a/dist/datetime.js
+++ b/dist/datetime.js
@@ -1106,7 +1106,7 @@ angular.module("datetime").directive("datetime", ["datetime", "$log", "$document
 		}
 
 		var validMin = function(value) {
-			if (ngModel.$isEmpty(value) || angular.isUndefined(attrs.min)) {
+			if (ngModel.$isEmpty(value) || ngModel.$isEmpty(attrs.min)) {
 				return true;
 			}
 			if (!angular.isDate(value)) {
@@ -1116,7 +1116,7 @@ angular.module("datetime").directive("datetime", ["datetime", "$log", "$document
 		};
 
 		var validMax = function(value) {
-			if (ngModel.$isEmpty(value) || angular.isUndefined(attrs.max)) {
+			if (ngModel.$isEmpty(value) || ngModel.$isEmpty(attrs.max)) {
 				return true;
 			}
 			if (!angular.isDate(value)) {

--- a/src/directive.js
+++ b/src/directive.js
@@ -227,7 +227,7 @@ angular.module("datetime").directive("datetime", function(datetime, $log, $docum
 		}
 
 		var validMin = function(value) {
-			if (ngModel.$isEmpty(value) || angular.isUndefined(attrs.min)) {
+			if (ngModel.$isEmpty(value) || ngModel.$isEmpty(attrs.min)) {
 				return true;
 			}
 			if (!angular.isDate(value)) {
@@ -237,7 +237,7 @@ angular.module("datetime").directive("datetime", function(datetime, $log, $docum
 		};
 
 		var validMax = function(value) {
-			if (ngModel.$isEmpty(value) || angular.isUndefined(attrs.max)) {
+			if (ngModel.$isEmpty(value) || ngModel.$isEmpty(attrs.max)) {
 				return true;
 			}
 			if (!angular.isDate(value)) {


### PR DESCRIPTION
I added a string empty check for attrs.min/attrs.max since I am using something like:

`<input ng-model="date" datetime="yyyy:MM:dd" min="{{ minDate | date:'yyyy:MM:dd' }}" />`

If minDate is undefined (min="") angular-datetime will still compare the ngModel against 
new Date(attrs.min) which will evaluate to new Date('') which is of course an invalid date.
This means the input will always be invalid.

 