### PR TITLE
Dealing with when there are no ngModel defined. 

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -179,6 +179,10 @@ angular.module("datetime").directive("datetime", function(datetime, $log, $docum
 	}
 
 	function linkFunc(scope, element, attrs, ngModel) {
+		if (ngModel === null) {
+			return false;
+		}
+
 		var parser = datetime(attrs.datetime),
 			modelParser = attrs.datetimeModel && datetime(attrs.datetimeModel),
 			range = {


### PR DESCRIPTION
This resolves conflict with other directives with similar names

An example:
```
<li data-datetime="{{ log.newDayTitle }}" ng-if="log.newDay" ng-repeat-start="log in logs" class="timeline-separator"></li>
```

```data-datetime``` is used for another directive. But I was getting uncaught reference error as ```ngModel``` variable was ```null```

This change will stop and return false instead