### PR TITLE
Ability to specify custom timezone in datetime-timezone attribute

### DIFF
--- a/example/demo-1.5.html
+++ b/example/demo-1.5.html
@@ -149,13 +149,13 @@
 	<div class="form-group">
 		<label>
 			UTC timezone
-			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-utc>
+			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="UTC">
 		</label>
 	</div>
 	<div class="form-group">
 		<label>
 			Custom Europe/Moscow timezone
-			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-utc="'+0300'">
+			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="'+0300'">
 		</label>
 	</div>
 	<div class="form-group">

--- a/example/demo-1.5.html
+++ b/example/demo-1.5.html
@@ -154,6 +154,12 @@
 	</div>
 	<div class="form-group">
 		<label>
+			Custom Europe/Moscow timezone
+			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-utc="'+0300'">
+		</label>
+	</div>
+	<div class="form-group">
+		<label>
 			datetime-model with min/max
 			<input type="text" class="form-control" datetime="yyyy-MM-dd" datetime-model="yyyy-MM-ddTHH:mm:ssZZ" ng-model="data.myDateString2" min="Jan 1, 2000">
 			<pre class="code"><code>{{data.myDateString2 | json}}</code></pre>

--- a/example/demo-1.5.html
+++ b/example/demo-1.5.html
@@ -149,13 +149,13 @@
 	<div class="form-group">
 		<label>
 			UTC timezone
-			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="'+0000'">
+			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="+0000">
 		</label>
 	</div>
 	<div class="form-group">
 		<label>
 			Custom Europe/Moscow timezone
-			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="'+0300'">
+			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="+0300">
 		</label>
 	</div>
 	<div class="form-group">

--- a/example/demo-1.5.html
+++ b/example/demo-1.5.html
@@ -37,12 +37,12 @@
 			$scope.reset = function(){
 				$scope.data.myDate = new Date;
 				$scope.data.myDateString = "2000-01-01 00:00:00";
-			}
+			};
 
 			$scope.clear = function(){
 				$scope.data.myDate = null;
 				$scope.data.myDateString = null;
-			}
+			};
 		});
 	</script>
 </head>

--- a/example/demo-1.5.html
+++ b/example/demo-1.5.html
@@ -149,7 +149,7 @@
 	<div class="form-group">
 		<label>
 			UTC timezone
-			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="UTC">
+			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="'+0000'">
 		</label>
 	</div>
 	<div class="form-group">

--- a/example/demo.html
+++ b/example/demo.html
@@ -149,13 +149,13 @@
 	<div class="form-group">
 		<label>
 			UTC timezone
-			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-utc>
+			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="UTC">
 		</label>
 	</div>
 	<div class="form-group">
 		<label>
 			Custom Europe/Moscow timezone
-			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-utc="'+0300'">
+			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="'+0300'">
 		</label>
 	</div>
 	<div class="form-group">

--- a/example/demo.html
+++ b/example/demo.html
@@ -154,6 +154,12 @@
 	</div>
 	<div class="form-group">
 		<label>
+			Custom Europe/Moscow timezone
+			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-utc="'+0300'">
+		</label>
+	</div>
+	<div class="form-group">
+		<label>
 			datetime-model with min/max
 			<input type="text" class="form-control" datetime="yyyy-MM-dd" datetime-model="yyyy-MM-ddTHH:mm:ssZZ" ng-model="data.myDateString2" min="Jan 1, 2000">
 			<pre class="code"><code>{{data.myDateString2 | json}}</code></pre>

--- a/example/demo.html
+++ b/example/demo.html
@@ -149,13 +149,13 @@
 	<div class="form-group">
 		<label>
 			UTC timezone
-			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="'+0000'">
+			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="+0000">
 		</label>
 	</div>
 	<div class="form-group">
 		<label>
 			Custom Europe/Moscow timezone
-			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="'+0300'">
+			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="+0300">
 		</label>
 	</div>
 	<div class="form-group">

--- a/example/demo.html
+++ b/example/demo.html
@@ -37,12 +37,12 @@
 			$scope.reset = function(){
 				$scope.data.myDate = new Date;
 				$scope.data.myDateString = "2000-01-01 00:00:00";
-			}
+			};
 
 			$scope.clear = function(){
 				$scope.data.myDate = null;
 				$scope.data.myDateString = null;
-			}
+			};
 		});
 	</script>
 </head>

--- a/example/demo.html
+++ b/example/demo.html
@@ -149,7 +149,7 @@
 	<div class="form-group">
 		<label>
 			UTC timezone
-			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="UTC">
+			<input type="text" class="form-control" datetime="yyyy-MM-dd HH:mm:ssZ" ng-model="data.myDate" datetime-timezone="'+0000'">
 		</label>
 	</div>
 	<div class="form-group">

--- a/lib/directive.js
+++ b/lib/directive.js
@@ -142,7 +142,7 @@ function init(datetime, $log, $document){
 		}
 
 		if (angular.isDefined(attrs.datetimeTimezone)) {
-			if (/[+-]\d{4}/.test(attrs.datetimeTimezone) || /[+-]\d{2}:\d{2}/.test(attrs.datetimeTimezone)) {
+			if (/[+-]\d{2}:?\d{2}/.test(attrs.datetimeTimezone)) {
 				scope.$watch(attrs.datetimeTimezone, setTimezone);
 			}
 		}

--- a/lib/directive.js
+++ b/lib/directive.js
@@ -145,9 +145,6 @@ function init(datetime, $log, $document){
 			if (/[+-]\d{4}/.test(attrs.datetimeTimezone)) {
 				scope.$watch(attrs.datetimeTimezone, setTimezone);
 			}
-			if (attrs.datetimeTimezone === 'UTC') {
-				setUtc(true);
-			}
 		}
 
 		function validMin(value) {

--- a/lib/directive.js
+++ b/lib/directive.js
@@ -112,14 +112,10 @@ function init(datetime, $log, $document){
 
 		function setUtc(val) {
 			if (val && !isUtc) {
-				var zone = "+0000";
-				if (typeof(val) !== typeof(true) && /[+-]\d{4}/.test(val)) {
-					zone = val;
-				}
 				isUtc = true;
-				parser.setTimezone(zone);
+				parser.setTimezone("+0000");
 				if (modelParser) {
-					modelParser.setTimezone(zone);
+					modelParser.setTimezone("+0000");
 				}
 			} else if (!val && isUtc) {
 				isUtc = false;
@@ -130,10 +126,26 @@ function init(datetime, $log, $document){
 			}
 		}
 
+		function setTimezone(val) {
+			parser.setTimezone(val);
+			if (modelParser) {
+				modelParser.setTimezone(val);
+			}
+		}
+
 		if (angular.isDefined(attrs.datetimeUtc)) {
 			if (attrs.datetimeUtc.length > 0) {
 				scope.$watch(attrs.datetimeUtc, setUtc);
 			} else {
+				setUtc(true);
+			}
+		}
+
+		if (angular.isDefined(attrs.datetimeTimezone)) {
+			if (/[+-]\d{4}/.test(attrs.datetimeTimezone)) {
+				scope.$watch(attrs.datetimeTimezone, setTimezone);
+			}
+			if (attrs.datetimeTimezone === 'UTC') {
 				setUtc(true);
 			}
 		}

--- a/lib/directive.js
+++ b/lib/directive.js
@@ -112,10 +112,14 @@ function init(datetime, $log, $document){
 
 		function setUtc(val) {
 			if (val && !isUtc) {
+				var zone = "+0000";
+				if (typeof(val) !== typeof(true) && /[+-]\d{4}/.test(val)) {
+					zone = val;
+				}
 				isUtc = true;
-				parser.setTimezone("+0000");
+				parser.setTimezone(zone);
 				if (modelParser) {
-					modelParser.setTimezone("+0000");
+					modelParser.setTimezone(zone);
 				}
 			} else if (!val && isUtc) {
 				isUtc = false;

--- a/lib/directive.js
+++ b/lib/directive.js
@@ -142,7 +142,9 @@ function init(datetime, $log, $document){
 		}
 
 		if (angular.isDefined(attrs.datetimeTimezone)) {
-			if (/[+-]\d{2}:?\d{2}/.test(attrs.datetimeTimezone)) {
+			if (/^[+-]\d{2}:?\d{2}$/.test(attrs.datetimeTimezone)) {
+				setTimezone(attrs.datetimeTimezone);
+			} else {
 				scope.$watch(attrs.datetimeTimezone, setTimezone);
 			}
 		}

--- a/lib/directive.js
+++ b/lib/directive.js
@@ -142,7 +142,7 @@ function init(datetime, $log, $document){
 		}
 
 		if (angular.isDefined(attrs.datetimeTimezone)) {
-			if (/[+-]\d{4}/.test(attrs.datetimeTimezone)) {
+			if (/[+-]\d{4}/.test(attrs.datetimeTimezone) || /[+-]\d{2}:\d{2}/.test(attrs.datetimeTimezone)) {
 				scope.$watch(attrs.datetimeTimezone, setTimezone);
 			}
 		}

--- a/test/test.js
+++ b/test/test.js
@@ -226,32 +226,38 @@ describe("datetime directive", function(){
 
 	it("datetime-timezone and custom timezone", function(){
 		$rootScope.date = new Date;
+		$rootScope.timezone = "'+0500'";
 
-		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone='\"+0300\"'>")($rootScope);
-
-		$rootScope.$digest();
-
-		assert.equal(element.val(), "+0300");
-	});
-
-	it("datetime-timezone and utc", function(){
-		$rootScope.date = new Date;
-
-		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone='\"+0000\"'>")($rootScope);
+		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone={{timezone}}>")($rootScope);
 
 		$rootScope.$digest();
 
-		assert.equal(element.val(), "+0000");
+		assert.equal(element.val(), "+0500");
 	});
 
 	it("datetime-timezone and utc format with colon", function(){
 		$rootScope.date = new Date;
+		$rootScope.timezone = "'+07:00'";
 
-		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone='\"+03:00\"'>")($rootScope);
+		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone={{timezone}}>")($rootScope);
 
 		$rootScope.$digest();
 
-		assert.equal(element.val(), "+0300");
+		assert.equal(element.val(), "+0700");
+	});
+
+	it("dynamic datetime-timezone", function(){
+		var date = $rootScope.date = new Date;
+		$rootScope.timezone = "'+0500'";
+
+		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone={{timezone}}>")($rootScope);
+		$rootScope.$digest();
+		assert.equal(element.val(), $date(date, "Z", "+0500"));
+
+		$rootScope.timezone = "'+0800'";
+		$rootScope.$digest();
+		assert.equal(element.val(), $date(date, "Z", "+0800"));
+
 	});
 	
 	it("dynamic datetime-utc", function(){

--- a/test/test.js
+++ b/test/test.js
@@ -224,14 +224,24 @@ describe("datetime directive", function(){
 		assert.equal(element.val(), "+0000");
 	});
 
-	it("custom timezone", function(){
+	it("datetime-timezone and custom timezone", function(){
 		$rootScope.date = new Date;
 
-		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-utc='\"+0300\"'>")($rootScope);
+		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone='\"+0300\"'>")($rootScope);
 
 		$rootScope.$digest();
 
 		assert.equal(element.val(), "+0300");
+	});
+
+	it("datetime-timezone and utc", function(){
+		$rootScope.date = new Date;
+
+		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone='UTC'>")($rootScope);
+
+		$rootScope.$digest();
+
+		assert.equal(element.val(), "+0000");
 	});
 	
 	it("dynamic datetime-utc", function(){

--- a/test/test.js
+++ b/test/test.js
@@ -226,9 +226,9 @@ describe("datetime directive", function(){
 
 	it("datetime-timezone and custom timezone", function(){
 		$rootScope.date = new Date;
-		$rootScope.timezone = "'+0500'";
+		$rootScope.timezone = "+0500";
 
-		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone={{timezone}}>")($rootScope);
+		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone='timezone'>")($rootScope);
 
 		$rootScope.$digest();
 
@@ -237,9 +237,9 @@ describe("datetime directive", function(){
 
 	it("datetime-timezone and utc format with colon", function(){
 		$rootScope.date = new Date;
-		$rootScope.timezone = "'+07:00'";
+		$rootScope.timezone = "+07:00";
 
-		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone={{timezone}}>")($rootScope);
+		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone='timezone'>")($rootScope);
 
 		$rootScope.$digest();
 
@@ -248,13 +248,13 @@ describe("datetime directive", function(){
 
 	it("dynamic datetime-timezone", function(){
 		var date = $rootScope.date = new Date;
-		$rootScope.timezone = "'+0500'";
+		$rootScope.timezone = "+0500";
 
-		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone={{timezone}}>")($rootScope);
+		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone='timezone'>")($rootScope);
 		$rootScope.$digest();
 		assert.equal(element.val(), $date(date, "Z", "+0500"));
 
-		$rootScope.timezone = "'+0800'";
+		$rootScope.timezone = "+0800";
 		$rootScope.$digest();
 		assert.equal(element.val(), $date(date, "Z", "+0800"));
 

--- a/test/test.js
+++ b/test/test.js
@@ -247,24 +247,24 @@ describe("datetime directive", function(){
 	});
 
 	it("dynamic datetime-timezone", function(){
-		var date = $rootScope.date = new Date;
+		$rootScope.date = new Date;
 		$rootScope.timezone = "+0500";
 
 		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone='timezone'>")($rootScope);
 		$rootScope.$digest();
-		assert.equal(element.val(), $date(date, "Z", "+0500"));
+		assert.equal(element.val(), "+0500");
 
 		$rootScope.timezone = "+0800";
 		$rootScope.$digest();
-		assert.equal(element.val(), $date(date, "Z", "+0800"));
+		assert.equal(element.val(), "+0800");
 	});
 
 	it("static datetime-timezone", function(){
-		var date = $rootScope.date = new Date;
+		$rootScope.date = new Date;
 
 		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone='+0500'>")($rootScope);
 		$rootScope.$digest();
-		assert.equal(element.val(), $date(date, "Z", "+0500"));
+		assert.equal(element.val(), "+0500");
 	});
 	
 	it("dynamic datetime-utc", function(){

--- a/test/test.js
+++ b/test/test.js
@@ -237,7 +237,7 @@ describe("datetime directive", function(){
 	it("datetime-timezone and utc", function(){
 		$rootScope.date = new Date;
 
-		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone='UTC'>")($rootScope);
+		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone='\"+0000\"'>")($rootScope);
 
 		$rootScope.$digest();
 

--- a/test/test.js
+++ b/test/test.js
@@ -223,6 +223,16 @@ describe("datetime directive", function(){
 		
 		assert.equal(element.val(), "+0000");
 	});
+
+	it("custom timezone", function(){
+		$rootScope.date = new Date;
+
+		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-utc='\"+0300\"'>")($rootScope);
+
+		$rootScope.$digest();
+
+		assert.equal(element.val(), "+0300");
+	});
 	
 	it("dynamic datetime-utc", function(){
 		var date = $rootScope.date = new Date;

--- a/test/test.js
+++ b/test/test.js
@@ -243,6 +243,16 @@ describe("datetime directive", function(){
 
 		assert.equal(element.val(), "+0000");
 	});
+
+	it("datetime-timezone and utc format with colon", function(){
+		$rootScope.date = new Date;
+
+		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone='\"+03:00\"'>")($rootScope);
+
+		$rootScope.$digest();
+
+		assert.equal(element.val(), "+0300");
+	});
 	
 	it("dynamic datetime-utc", function(){
 		var date = $rootScope.date = new Date;

--- a/test/test.js
+++ b/test/test.js
@@ -257,7 +257,14 @@ describe("datetime directive", function(){
 		$rootScope.timezone = "+0800";
 		$rootScope.$digest();
 		assert.equal(element.val(), $date(date, "Z", "+0800"));
+	});
 
+	it("static datetime-timezone", function(){
+		var date = $rootScope.date = new Date;
+
+		var element = $compile("<input type='text' datetime='Z' ng-model='date' datetime-timezone='+0500'>")($rootScope);
+		$rootScope.$digest();
+		assert.equal(element.val(), $date(date, "Z", "+0500"));
 	});
 	
 	it("dynamic datetime-utc", function(){


### PR DESCRIPTION
Added ability to specify the custom timezone string in directive
```datetime-timezone="+0300"``` for example
If you need to set time in UTC timezone, simply pass "UTC" as param.
```datetime-timezone="+0000"```